### PR TITLE
Fix malformed kitctf link in nixpkgs-gha-pwn blogpost

### DIFF
--- a/_posts/2025-09-11-nixpkgs-actions-abuse.md
+++ b/_posts/2025-09-11-nixpkgs-actions-abuse.md
@@ -147,7 +147,7 @@ it only took us about a day to find, report, and help fix a vulnerability that c
 big thanks to intrigus and everyone at KITCTF (intrigus gave [a talk about exactly these issues](https://kitctf.de/learning/insecure-github-actions) that taught us how this works), and thanks to infinisil for fixing this on the same day we reported it.
 
 if you want to learn more, check out these resources:
-- [https://kitctf.de/talks/2023-10-26-insecure-github-actions/insecure-github-actions.pdf](https://kitctf.de/talks/2023-10-26-insecure-github-actions/insecure-github-actions.pdf])
+- [https://kitctf.de/talks/2023-10-26-insecure-github-actions/insecure-github-actions.pdf](https://kitctf.de/talks/2023-10-26-insecure-github-actions/insecure-github-actions.pdf)
 - [https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)
 - [https://github.com/NixOS/nixpkgs/pull/351446](https://github.com/NixOS/nixpkgs/pull/351446)
 


### PR DESCRIPTION
This pull request makes a minor correction to a Markdown link in the blog post `_posts/2025-09-11-nixpkgs-actions-abuse.md` to fix a formatting issue.

- Fixed a typo in a Markdown link by removing an extra closing bracket to ensure the link renders correctly.